### PR TITLE
Add orange labeler (#9)

### DIFF
--- a/aws/.github/label.yml
+++ b/aws/.github/label.yml
@@ -1,0 +1,10 @@
+name: Add `orange` label to new issues and PRs
+on: [issues, pull_request]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: DataBiosphere/azul-github-labeler-action@releases/v4
+      with:
+        repo-token: "${{secrets.GITHUB_TOKEN}}"
+        label: orange


### PR DESCRIPTION
Repo key needs to be configured in settings by an admin.