### PR TITLE
Moving the report date back one day

### DIFF
--- a/report.py
+++ b/report.py
@@ -529,7 +529,7 @@ class GCPReport(Report):
             ORDER BY LOWER(project.name) ASC, service.description ASC'''
         query_job = client.query(query)
         rows = list(query_job.result())
-        return self.render_email(self.date.today(), self.email_recipients, rows=rows)
+        return self.render_email(self.date, self.email_recipients, rows=rows)
 
 
 def print_amount(amount: Union[Decimal, float, int]) -> str:
@@ -653,6 +653,10 @@ if __name__ == '__main__':
                         default=Path.cwd() / 'config.json',
                         help='Path to config.json. Default to current directory.')
     arguments = parser.parse_args()
+
+    if arguments.report_type == "gcp":
+        arguments.report_date = (datetime.datetime.now() - datetime.timedelta(days=2)).strftime(date_format)
+
     date = datetime.datetime.strptime(arguments.report_date, date_format).date()
     report = report_types[arguments.report_type](arguments.config, date)
     print(report.generateBetterReport())


### PR DESCRIPTION
The Google BigQuery dataset takes time to populate with the previous day's billing data. This makes the report, which runs early in the morning, generally run on a partially complete dataset. To remedy this, have the Google report run 2 against billing data from 2 days back.