### PR TITLE
Add inverted "Details" table, and sort in descending cost order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8.6-slim
-LABEL maintainer="natanlao@users.noreply.github.com"
+LABEL maintainer="svonworl@users.noreply.github.com"
 LABEL org.opencontainers.image.source https://github.com/ucsc-cgp/cloud-billing-report
 
 COPY requirements.txt .

--- a/report.py
+++ b/report.py
@@ -70,8 +70,9 @@ class Report:
             'group_by': group_by,
             'filter_by': filter_by,
             'sort_by': sort_by,
-            'to_id': to_id,
-            'print_diff': lambda a: print_diff(a, self.warning_threshold)
+            'to_project_id': to_project_id,
+            'to_service_id': to_service_id,
+            'print_diff': lambda a: print_diff(a, self.warning_threshold),
         })
 
     @property
@@ -770,6 +771,12 @@ def to_id(value: str) -> str:
     '-ABC-1-2-3-'
     """
     return re.sub('[^a-zA-Z0-9]', '-', value)
+
+def to_project_id(value: str) -> str:
+    return 'project-' + to_id(value)
+
+def to_service_id(value: str) -> str:
+    return 'service-' + to_id(value)
 
 report_types = {
     'aws': AWSReport,

--- a/report.py
+++ b/report.py
@@ -763,7 +763,7 @@ def sort_by(rows: Iterable, key, reverse=True) -> Iterable:
     """
     rows_with_keys = [row for row in rows if has_key(row, key)]
     rows_without_keys = [row for row in rows if not has_key(row, key)]
-    return sorted(rows_with_keys, key=lambda row: normalize_key(row[key]), reverse=reverse) + rows_without_keys;
+    return sorted(rows_with_keys, key=lambda row: normalize_key(row[key]), reverse=reverse) + rows_without_keys
 
 
 def to_id(value: str) -> str:

--- a/report.py
+++ b/report.py
@@ -20,6 +20,7 @@ from pathlib import (
 )
 import tempfile
 from typing import (
+    Iterable,
     Iterator,
     Mapping,
     Sequence,
@@ -67,6 +68,7 @@ class Report:
             'sum_key': lambda rows, key: sum(row[key] for row in rows),
             'group_by': group_by,
             'filter_by': filter_by,
+            'sort_by': sort_by,
             'print_diff': lambda a: print_diff(a, self.warning_threshold)
         })
 
@@ -727,6 +729,21 @@ def group_by(rows: Sequence[Mapping[str, int]],
         for k, vals in grouped
     )
 
+def sort_by(values: Iterable, key, missing=0, reverse=True) -> Iterable:
+    """
+    >>> my_rows = [
+    ...     {'foo': 3, 'bar': 1},
+    ...     {'foo': 1, 'bar': 3},
+    ...     {'foo': 2, 'bar': 2}
+    ... ]
+
+    >>> list(sort_by(my_rows, 'bar'))
+    [{'foo': 1, 'bar': 3}, {'foo': 2, 'bar': 2}, {'foo': 3, 'bar': 1}]
+
+    >>> list(sort_by(my_rows, 'foo', reverse=False))
+    [{'foo': 1, 'bar': 3}, {'foo': 2, 'bar': 2}, {'foo': 3, 'bar': 1}]
+    """
+    return sorted(values, key=lambda row: row[key] or missing, reverse=reverse)
 
 report_types = {
     'aws': AWSReport,

--- a/report.py
+++ b/report.py
@@ -70,8 +70,8 @@ class Report:
             'group_by': group_by,
             'filter_by': filter_by,
             'sort_by': sort_by,
-            'to_project_id': to_project_id,
-            'to_service_id': to_service_id,
+            'to_project_id': lambda value: 'project-' + to_id(value),
+            'to_service_id': lambda value: 'service-' + to_id(value),
             'print_diff': lambda a: print_diff(a, self.warning_threshold),
         })
 
@@ -775,14 +775,6 @@ def to_id(value: str) -> str:
     '-ABC-1-2-3-'
     """
     return re.sub('[^a-zA-Z0-9]', '-', value)
-
-
-def to_project_id(value: str) -> str:
-    return 'project-' + to_id(value)
-
-
-def to_service_id(value: str) -> str:
-    return 'service-' + to_id(value)
 
 
 report_types = {

--- a/report.py
+++ b/report.py
@@ -18,6 +18,7 @@ import operator
 from pathlib import (
     Path,
 )
+import re
 import tempfile
 from typing import (
     Iterable,
@@ -69,6 +70,7 @@ class Report:
             'group_by': group_by,
             'filter_by': filter_by,
             'sort_by': sort_by,
+            'to_id': to_id,
             'print_diff': lambda a: print_diff(a, self.warning_threshold)
         })
 
@@ -720,7 +722,6 @@ def group_by(rows: Sequence[Mapping[str, int]],
     >>> list(group_by(my_rows, 'foo', 'bar', 'baz', baz=2))
     [(1, 3, 2)]
 
-    # TODO add to_id
     """
     sorted = sort_by(rows, key=key, reverse=False)
     grouped = (
@@ -759,6 +760,16 @@ def sort_by(rows: Iterable, key, reverse=True) -> Iterable:
     rows_with_keys = [row for row in rows if has_key(row, key)]
     rows_without_keys = [row for row in rows if not has_key(row, key)]
     return sorted(rows_with_keys, key=lambda row: normalize_key(row[key]), reverse=reverse) + rows_without_keys;
+
+def to_id(value: str) -> str:
+    """
+    >>> to_id('abc123')
+    'abc123'
+
+    >>> to_id('.ABC 1-2-3!')
+    '-ABC-1-2-3-'
+    """
+    return re.sub('[^a-zA-Z0-9]', '-', value)
 
 report_types = {
     'aws': AWSReport,

--- a/report.py
+++ b/report.py
@@ -734,14 +734,17 @@ def group_by(rows: Sequence[Mapping[str, int]],
         for k, vals in grouped
     )
 
+
 def has_key(value, key):
     try:
-        return value[key] is not None;
+        return value[key] is not None
     except KeyError:
-        return False;
+        return False
+
 
 def normalize_key(key):
     return key.lower() if isinstance(key, str) else key
+
 
 def sort_by(rows: Iterable, key, reverse=True) -> Iterable:
     """
@@ -762,6 +765,7 @@ def sort_by(rows: Iterable, key, reverse=True) -> Iterable:
     rows_without_keys = [row for row in rows if not has_key(row, key)]
     return sorted(rows_with_keys, key=lambda row: normalize_key(row[key]), reverse=reverse) + rows_without_keys;
 
+
 def to_id(value: str) -> str:
     """
     >>> to_id('abc123')
@@ -772,11 +776,14 @@ def to_id(value: str) -> str:
     """
     return re.sub('[^a-zA-Z0-9]', '-', value)
 
+
 def to_project_id(value: str) -> str:
     return 'project-' + to_id(value)
 
+
 def to_service_id(value: str) -> str:
     return 'service-' + to_id(value)
+
 
 report_types = {
     'aws': AWSReport,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.17.51
-google-cloud-bigquery==2.2.0
+google-cloud-bigquery==3.4.0
 Jinja2==2.11.3
 python-dateutil==2.8.1
 markupsafe==2.0.1

--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -30,7 +30,7 @@
         </tfoot>
     </table>
 
-    {% for project, month_total, today_total in rows|group_by('name', 'cost_month', 'cost_today') %}
+    {% for project, month_total, today_total in rows|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
         <a name='{{ project }}' id='{{ project }}'></a>
         <h2>Report for project {{ project }}</h2>
         <table>
@@ -42,9 +42,9 @@
             </tr>
             </thead>
             <tbody>
-            {% for service, month_cost, today_cost in rows|filter_by(name=project)|group_by('description', 'cost_month', 'cost_today') %}
+            {% for service, month_cost, today_cost in rows|filter_by(name=project)|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
                 <tr>
-                    <td>{{ service }}</td>
+                    <td><a href='#{{ service }}'>{{ service }}</a></td>
                     <td>{{ month_cost|print_amount }}</td>
                     <td>{{ today_cost|print_diff }}</td>
                 </tr>
@@ -59,4 +59,36 @@
             </tfoot>
         </table>
     {% endfor %}
+
+    {% for service, month_total, today_total in rows|sort_by('description', '')|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
+         <a name='{{ service }}' id='{{ service }}'></a>
+         <h2>Report for service {{ service }}</h2>
+         <table>
+             <thead>
+             <tr>
+                <th>Project</th>
+                <th>{{ report_date|ym }}</th>
+                <th>{{ report_date|ymd }}</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for project, month_cost, today_cost in rows|filter_by(description=service)|sort_by('name', '')|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
+                <tr>
+                    <td><a href='#{{ project }}'>{{ project }}</a></td>
+                    <td>{{ month_cost|print_amount }}</td>
+                    <td>{{ today_cost|print_diff }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+            <tfoot>
+            <tr>
+                <td>Grand total</td>
+                <td>{{ month_total|print_amount }}</td>
+                <td>{{ today_total|print_diff }}</td>
+            </tr>
+            </tfoot>
+        </table>
+
+    {% endfor %}
+
 {% endblock main %}

--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -15,7 +15,7 @@
         <tbody>
         {% for project, cost_month, cost_today in rows|group_by('name', 'cost_month', 'cost_today') %}
             <tr>
-                <td><a href='#{{ project|to_id }}'>{{ project }}</a></td>
+                <td><a href='#{{ project|to_project_id }}'>{{ project }}</a></td>
                 <td>{{ cost_month|print_amount }}</td>
                 <td>{{ cost_today|print_diff }}</td>
             </tr>
@@ -32,7 +32,7 @@
 
     <h2>Details by project</h2>
     {% for project, month_total, today_total in rows|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
-        <a name='{{ project|to_id }}' id='{{ project|to_id }}'></a>
+        <a name='{{ project|to_project_id }}' id='{{ project|to_project_id }}'></a>
         <h3>Report for project {{ project }}</h3>
         <table>
             <thead>
@@ -45,7 +45,7 @@
             <tbody>
             {% for service, month_cost, today_cost in rows|filter_by(name=project)|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
                 <tr>
-                    <td><a href='#{{ service|to_id }}'>{{ service }}</a></td>
+                    <td><a href='#{{ service|to_service_id }}'>{{ service }}</a></td>
                     <td>{{ month_cost|print_amount }}</td>
                     <td>{{ today_cost|print_diff }}</td>
                 </tr>
@@ -63,7 +63,7 @@
 
     <h2>Details by service</h2>
     {% for service, month_total, today_total in rows|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
-         <a name='{{ service|to_id }}' id='{{ service|to_id }}'></a>
+         <a name='{{ service|to_service_id }}' id='{{ service|to_service_id }}'></a>
          <h3>Report for service {{ service }}</h3>
          <table>
              <thead>
@@ -76,7 +76,7 @@
             <tbody>
             {% for project, month_cost, today_cost in rows|filter_by(description=service)|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
                 <tr>
-                    <td><a href='#{{ project|to_id }}'>{{ project }}</a></td>
+                    <td><a href='#{{ project|to_project_id }}'>{{ project }}</a></td>
                     <td>{{ month_cost|print_amount }}</td>
                     <td>{{ today_cost|print_diff }}</td>
                 </tr>

--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -30,9 +30,10 @@
         </tfoot>
     </table>
 
+    <h2>Details by project</h2>
     {% for project, month_total, today_total in rows|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
         <a name='{{ project }}' id='{{ project }}'></a>
-        <h2>Report for project {{ project }}</h2>
+        <h3>Report for project {{ project }}</h3>
         <table>
             <thead>
             <tr>
@@ -60,9 +61,10 @@
         </table>
     {% endfor %}
 
-    {% for service, month_total, today_total in rows|sort_by('description', '')|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
+    <h2>Details by service</h2>
+    {% for service, month_total, today_total in rows|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
          <a name='{{ service }}' id='{{ service }}'></a>
-         <h2>Report for service {{ service }}</h2>
+         <h3>Report for service {{ service }}</h3>
          <table>
              <thead>
              <tr>
@@ -72,7 +74,7 @@
             </tr>
             </thead>
             <tbody>
-            {% for project, month_cost, today_cost in rows|filter_by(description=service)|sort_by('name', '')|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
+            {% for project, month_cost, today_cost in rows|filter_by(description=service)|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
                 <tr>
                     <td><a href='#{{ project }}'>{{ project }}</a></td>
                     <td>{{ month_cost|print_amount }}</td>
@@ -88,7 +90,6 @@
             </tr>
             </tfoot>
         </table>
-
     {% endfor %}
 
 {% endblock main %}

--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -15,7 +15,7 @@
         <tbody>
         {% for project, cost_month, cost_today in rows|group_by('name', 'cost_month', 'cost_today') %}
             <tr>
-                <td><a href='#{{ project }}'>{{ project }}</a></td>
+                <td><a href='#{{ project|to_id }}'>{{ project }}</a></td>
                 <td>{{ cost_month|print_amount }}</td>
                 <td>{{ cost_today|print_diff }}</td>
             </tr>
@@ -32,7 +32,7 @@
 
     <h2>Details by project</h2>
     {% for project, month_total, today_total in rows|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
-        <a name='{{ project }}' id='{{ project }}'></a>
+        <a name='{{ project|to_id }}' id='{{ project|to_id }}'></a>
         <h3>Report for project {{ project }}</h3>
         <table>
             <thead>
@@ -45,7 +45,7 @@
             <tbody>
             {% for service, month_cost, today_cost in rows|filter_by(name=project)|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
                 <tr>
-                    <td><a href='#{{ service }}'>{{ service }}</a></td>
+                    <td><a href='#{{ service|to_id }}'>{{ service }}</a></td>
                     <td>{{ month_cost|print_amount }}</td>
                     <td>{{ today_cost|print_diff }}</td>
                 </tr>
@@ -63,7 +63,7 @@
 
     <h2>Details by service</h2>
     {% for service, month_total, today_total in rows|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
-         <a name='{{ service }}' id='{{ service }}'></a>
+         <a name='{{ service|to_id }}' id='{{ service|to_id }}'></a>
          <h3>Report for service {{ service }}</h3>
          <table>
              <thead>
@@ -76,7 +76,7 @@
             <tbody>
             {% for project, month_cost, today_cost in rows|filter_by(description=service)|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
                 <tr>
-                    <td><a href='#{{ project }}'>{{ project }}</a></td>
+                    <td><a href='#{{ project|to_id }}'>{{ project }}</a></td>
                     <td>{{ month_cost|print_amount }}</td>
                     <td>{{ today_cost|print_diff }}</td>
                 </tr>


### PR DESCRIPTION
This PR implements a couple of features to the GCP report that Benedict requested during a 10/Apr/2023 conversation:

1. A new "Details by service" section, which contains a table for each service, listing the costs by platform and in total.  Essentially, this is an inversion of the "Details by platform" section.
2. The existing "Details by platform" and new "Details by service" sections are [now] sorted in descending cost order, so that the tables and table rows with the highest monthly cost appear first.

I added links throughout, from the platform/service name to the appropriate "Details" table.
The alphabetical sorting of the summary "total" information at the beginning of the report has not changed.
