### PR TITLE
Update action to use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ jobs:
         run: docker build -t report .
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
         run: |


### PR DESCRIPTION
This PR updates the docker-publish action workflow to use `GITHUB_TOKEN`, as recommended here:
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry