### PR TITLE
Add permissions to docker-publish action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,10 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     if: github.event_name == 'push'
 
     steps:


### PR DESCRIPTION
See https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages