### PR TITLE
Revert docker-publish token changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,10 +10,6 @@ jobs:
   # See also https://docs.docker.com/docker-hub/builds/
   push:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     if: github.event_name == 'push'
 
     steps:
@@ -23,7 +19,7 @@ jobs:
         run: docker build -t report .
 
       - name: Log into GitHub Container Registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image to GitHub Container Registry
         run: |


### PR DESCRIPTION
This PR reverts some experimental token changes to the previous code that uses a personal access token to push images to ghcr.io