### PR TITLE
Fix usage file download bug

### DIFF
--- a/report.py
+++ b/report.py
@@ -192,6 +192,7 @@ class AWSReport(Report):
         for s3_report_archive_path in reportKeys:
             with tempfile.NamedTemporaryFile() as tmp:
                 s3.download_fileobj(self.bucket, s3_report_archive_path, tmp)
+                tmp.flush()
                 with gzip.open(tmp.name, 'r') as report_fp:
                     fileLines = report_fp.read().decode().splitlines()
                     allLines.extend(fileLines)


### PR DESCRIPTION
The existing code uses `s3.download_fileobj` to download the usage files from S3.  `download_fileobj` multithreads large downloads, but does not flush the downloaded file contents.  So, we must `flush` before we `open` the downloaded file to process it, because if we don't, the downloaded file will sometimes appear truncated and or contain holes.

This PR adds a `flush` in the appropriate location.