### PR TITLE
Ignore "edp discount" rows

### DIFF
--- a/report.py
+++ b/report.py
@@ -410,7 +410,7 @@ class AWSReport(Report):
         for row in reportCsv:
 
             # skip rows that involve us getting money back.
-            if row['lineItem/LineItemType'].lower() in ['credit', 'refund']:
+            if row['lineItem/LineItemType'].lower() in ['credit', 'refund', 'edpdiscount']:
                 continue
 
             account = self.accounts.get(row['lineItem/UsageAccountId'], '(unknown)')  # account for resource


### PR DESCRIPTION
Recently, in the raw AWS data, rows which reflect EDP discounts (`LineItemType` of `EdpDiscount`) began to appear, which made our processing code fail because the said rows have a blank string as the "blended" cost, causing the decimal string conversion to throw. 

This change causes EDP discount-related rows to be ignored, similarly to how we currently treat credits and refunds.