### PR TITLE
Bump actions/checkout version

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.event_name == 'push'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build image
         run: docker build -t report .


### PR DESCRIPTION
Increases the version of the github checkout action to `v3` to avoid a stale node dependency.