### PR TITLE
Update python image to 3.11.5 and boto3 to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-slim
+FROM python:3.11.5-slim
 LABEL maintainer="svonworl@users.noreply.github.com"
 LABEL org.opencontainers.image.source https://github.com/ucsc-cgp/cloud-billing-report
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto3==1.17.51
+boto3==1.28.37
 google-cloud-bigquery==3.4.0
 Jinja2==2.11.3
 python-dateutil==2.8.1


### PR DESCRIPTION
The reporting image is experiencing an occasional failure due to what appears to be a DNS name lookup problem.  As part of the campaign to eliminate the issue, update the python image to 3.11.5 and the boto3 package to the latest version, just in case the bug is in that part of the stack.