### PR TITLE
Aggregate gcp report by project ID

### DIFF
--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -11,7 +11,7 @@
     <table>
         <thead>
         <tr>
-            <th>Project</th>
+            <th>Project Name</th>
             <th>{{ report_date|ym }}</th>
             <th>{{ report_date|ymd }}</th>
         </tr>
@@ -41,9 +41,11 @@
       {%- if month_total >= cost_cutoff -%}
         <a name='{{ id|to_project_id }}' id='{{ id|to_project_id }}'></a>
         <h3>Report for project {{ project }}</h3>
+        <p>GCP project ID: <a href="https://console.cloud.google.com/welcome?project={{ id }}">{{ id }}</a>
         {% if id in terra_workspaces and 'createdBy' in terra_workspaces[id] %}
-          <p>Terra workspace created by {{ terra_workspaces[id]['createdBy'] }}, GCP ID {{ id }}</p>
+          <br>Terra workspace created by {{ terra_workspaces[id]['createdBy'] }}
         {% endif %}
+        </p>
         <table>
             <thead>
             <tr>
@@ -82,7 +84,7 @@
          <table>
              <thead>
              <tr>
-                <th>Project</th>
+                <th>Project Name</th>
                 <th>{{ report_date|ym }}</th>
                 <th>{{ report_date|ymd }}</th>
             </tr>

--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -17,10 +17,10 @@
         </tr>
         </thead>
         <tbody>
-        {% for project, cost_month, cost_today in rows|group_by('name', 'cost_month', 'cost_today') %}
+        {% for id, cost_month, cost_today, project in rows|group_by('id', 'cost_month', 'cost_today', 'name')|sort_by(3, reverse=False) %}
           {%- if cost_month >= cost_cutoff -%}
             <tr>
-                <td><a href='#{{ project|to_project_id }}'>{{ project }}</a></td>
+                <td><a href='#{{ id|to_project_id }}'>{{ project }}</a></td>
                 <td>{{ cost_month|print_amount }}</td>
                 <td>{{ cost_today|print_diff }}</td>
             </tr>
@@ -37,12 +37,12 @@
     </table>
 
     <h2>Details by project</h2>
-    {% for project, month_total, today_total in rows|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
+    {% for id, month_total, today_total, project in rows|group_by('id', 'cost_month', 'cost_today', 'name')|sort_by(1) %}
       {%- if month_total >= cost_cutoff -%}
-        <a name='{{ project|to_project_id }}' id='{{ project|to_project_id }}'></a>
+        <a name='{{ id|to_project_id }}' id='{{ id|to_project_id }}'></a>
         <h3>Report for project {{ project }}</h3>
-        {% if project in terra_workspaces and 'createdBy' in terra_workspaces[project] %}
-          <p>Terra workspace created by {{ terra_workspaces[project]['createdBy'] }}</p>
+        {% if id in terra_workspaces and 'createdBy' in terra_workspaces[id] %}
+          <p>Terra workspace created by {{ terra_workspaces[id]['createdBy'] }}, GCP ID {{ id }}</p>
         {% endif %}
         <table>
             <thead>
@@ -53,7 +53,7 @@
             </tr>
             </thead>
             <tbody>
-            {% for service, month_cost, today_cost in rows|filter_by(name=project)|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
+            {% for service, month_cost, today_cost in rows|filter_by(id=id)|group_by('description', 'cost_month', 'cost_today')|sort_by(1) %}
               {%- if month_cost >= cost_cutoff -%}
                 <tr>
                     <td><a href='#{{ service|to_service_id }}'>{{ service }}</a></td>
@@ -88,10 +88,10 @@
             </tr>
             </thead>
             <tbody>
-            {% for project, month_cost, today_cost in rows|filter_by(description=service)|group_by('name', 'cost_month', 'cost_today')|sort_by(1) %}
+            {% for id, month_cost, today_cost, project in rows|filter_by(description=service)|group_by('id', 'cost_month', 'cost_today', 'name')|sort_by(1) %}
               {%- if month_cost >= cost_cutoff -%}
                 <tr>
-                    <td><a href='#{{ project|to_project_id }}'>{{ project }}</a></td>
+                    <td><a href='#{{ id|to_project_id }}'>{{ project }}</a></td>
                     <td>{{ month_cost|print_amount }}</td>
                     <td>{{ today_cost|print_diff }}</td>
                 </tr>


### PR DESCRIPTION
Previously, the reporting script was aggregating cost data using the project name, which is not necessarily unique, and for Terra GCP projects, is formed by concatenating the Terra namespace, `--`, and the Terra project name.    Google limits project names to 30 chars, so the upshot is that for long namespaces, there's truncation, and multiple Terra projects were getting aggregated into one entry in the report.

This PR changes the script to aggregate on the GCP project ID, which is globally unique.  It also tweaks the output slightly.