### PR TITLE
Only process lines in aws data that refer to a cost

### DIFF
--- a/report.py
+++ b/report.py
@@ -415,8 +415,9 @@ class AWSReport(Report):
 
         for row in reportCsv:
 
-            # skip rows that involve us getting money back.
-            if row['lineItem/LineItemType'].lower() in ['credit', 'refund', 'edpdiscount']:
+            # skip rows that don't involve a cost, typicall those that refer to a discount, credit, or refund
+            itemType = row['lineItem/LineItemType'];
+            if not (itemType.endswith('Usage') or itemType.endswith('Fee') or itemType.endswith('Tax')):
                 continue
 
             account = self.accounts.get(row['lineItem/UsageAccountId'], '(unknown)')  # account for resource

--- a/report.py
+++ b/report.py
@@ -416,7 +416,7 @@ class AWSReport(Report):
         for row in reportCsv:
 
             # skip rows that don't involve a cost, typicall those that refer to a discount, credit, or refund
-            itemType = row['lineItem/LineItemType'];
+            itemType = row['lineItem/LineItemType']
             if not (itemType.endswith('Usage') or itemType.endswith('Fee') or itemType.endswith('Tax')):
                 continue
 


### PR DESCRIPTION
A previously-unseen discount type began to appear in the AWS data, the lines for which the `blendedCost` value was empty, causing the reporting script to crash.  This PR changes the AWS report to only process lines in the data that correspond to a cost (lines with a `LineItemType` that ends with `Usage`, `Fee`, or `Tax`).