### PR TITLE
Fix "None" project names in GCP report 

### DIFF
--- a/report.py
+++ b/report.py
@@ -778,7 +778,7 @@ def reduce(values: Sequence):
     if isinstance(values[0], numbers.Number):
         return sum(values)
     else:
-        return values[0]
+        return next((v for v in values if v is not None), None)
 
 
 def has_key(value, key):


### PR DESCRIPTION
In the GCP report, some projects were named "None", because some of the data that Google returned contained a null `project.name` field.  These results were interspersed with data that contained the correct `project.name` value.

The fix is to change the `reduce()` method (that aggregates values) to prefer a non-`None` value when it is reducing a list of strings.  This will cause the correct name to be displayed if Google returned any records that contained the correct project name for a given project id.

