### PR TITLE
Persist usage data

### DIFF
--- a/report.py
+++ b/report.py
@@ -152,7 +152,7 @@ class Report:
 
     @property
     def has_persist_config(self) -> bool:
-        return self._config_global['persist'] is not None
+        return 'persist' in self._config_global
 
     def render_email(self,
                      report_date: datetime.date,

--- a/report.py
+++ b/report.py
@@ -23,6 +23,7 @@ from pathlib import (
 import re
 import tempfile
 from typing import (
+    Any,
     Iterable,
     Iterator,
     Mapping,
@@ -150,7 +151,7 @@ class Report:
         return self._config_global['persist']['bucket']
 
     @property
-    def has_persist_config(self) -> str:
+    def has_persist_config(self) -> bool:
         return self._config_global['persist'] is not None
 
     def render_email(self,
@@ -213,7 +214,7 @@ class Report:
     def generateTerraJsonFileName(self, date: datetime.date) -> str:
         return self.generateFileName('terra', (str(date.year), str(date.month), str(date.day)), 'terra', 'json')
 
-    def toCsv(self, rows: Sequence[Mapping[str, str]]) -> str:
+    def toCsv(self, rows: Sequence[Mapping[str, Any]]) -> str:
         with io.StringIO('') as file:
             csvWriter = csv.DictWriter(file, fieldnames=rows[0].keys())
             csvWriter.writeheader()
@@ -223,6 +224,9 @@ class Report:
 
     def toJson(self, parsed_json) -> str:
         return json.dumps(parsed_json, indent=2)
+
+    def isoDate(self, date: datetime.date) -> str:
+        return date.strftime("%Y-%m-%d")
 
 
 class AWSReport(Report):
@@ -335,9 +339,6 @@ class AWSReport(Report):
 
         accountIds = list(accounts.keys())
 
-        startDate = startDate.strftime("%Y-%m-%d")
-        endDate = endDate.strftime("%Y-%m-%d")
-
         billingClient = boto3.client('ce',
                                      aws_access_key_id=self.access_key,
                                      aws_secret_access_key=self.secret_key)
@@ -345,8 +346,8 @@ class AWSReport(Report):
         # Make the request
         result = billingClient.get_cost_and_usage(
             TimePeriod={
-                'Start': startDate,
-                'End': endDate
+                'Start': self.isoDate(startDate),
+                'End': self.isoDate(endDate)
             },
             Granularity="MONTHLY",
             Filter={
@@ -403,9 +404,6 @@ class AWSReport(Report):
 
         accountIds = list(accounts.keys())
 
-        startDate = startDate.strftime("%Y-%m-%d")
-        endDate = endDate.strftime("%Y-%m-%d")
-
         billingClient = boto3.client('ce',
                                      aws_access_key_id=self.access_key,
                                      aws_secret_access_key=self.secret_key)
@@ -413,8 +411,8 @@ class AWSReport(Report):
         # Make the request
         result = billingClient.get_cost_and_usage(
             TimePeriod={
-                'Start': startDate,
-                'End': endDate
+                'Start': self.isoDate(startDate),
+                'End': self.isoDate(endDate)
             },
             Granularity="MONTHLY",
             Filter={
@@ -512,9 +510,6 @@ class AWSReport(Report):
 
         accountIds = list(accounts.keys())
 
-        startDate = startDate.strftime("%Y-%m-%d")
-        endDate = endDate.strftime("%Y-%m-%d")
-
         billingClient = boto3.client('ce',
                                      aws_access_key_id=self.access_key,
                                      aws_secret_access_key=self.secret_key)
@@ -522,8 +517,8 @@ class AWSReport(Report):
         # Make the request
         result = billingClient.get_cost_and_usage(
             TimePeriod={
-                'Start': startDate,
-                'End': endDate
+                'Start': self.isoDate(startDate),
+                'End': self.isoDate(endDate)
             },
             Granularity="MONTHLY",
             Filter={

--- a/report.py
+++ b/report.py
@@ -21,7 +21,6 @@ from pathlib import (
     Path,
 )
 import re
-import sys
 import tempfile
 from typing import (
     Iterable,
@@ -152,7 +151,7 @@ class Report:
 
     @property
     def has_persist_config(self) -> str:
-        return self._config_global['persist'] != None
+        return self._config_global['persist'] is not None
 
     def render_email(self,
                      report_date: datetime.date,
@@ -188,8 +187,10 @@ class Report:
         return date.replace(day=1)
 
     def lastDayOfMonth(self, date: datetime.date) -> datetime.date:
-        return datetime.date(date.year + (date.month == 12),
-            (date.month + 1 if date.month < 12 else 1), 1) - datetime.timedelta(1)
+        return datetime.date(
+            date.year + (date.month == 12),
+            (date.month + 1 if date.month < 12 else 1), 1
+        ) - datetime.timedelta(1)
 
     def daysOfMonthUpToAndIncluding(self, date: datetime.date) -> Sequence[datetime.date]:
         firstDayOfMonth = self.firstDayOfMonth(date)
@@ -210,7 +211,7 @@ class Report:
         return self.generateFileName(self.platform, (str(date.year), str(date.month)), self.platform, 'csv')
 
     def generateTerraJsonFileName(self, date: datetime.date) -> str:
-        return self.generateFileName('terra', (str(date.year), str(date.month), str(date.day)), 'terra', 'json');
+        return self.generateFileName('terra', (str(date.year), str(date.month), str(date.day)), 'terra', 'json')
 
     def toCsv(self, rows: Sequence[Mapping[str, str]]) -> str:
         with io.StringIO('') as file:
@@ -708,9 +709,11 @@ class GCPReport(Report):
         return []
 
     def removeNonUcsc(self, terra_workspaces: Sequence[Mapping]) -> Sequence[Mapping]:
-        return [mapping for mapping in terra_workspaces if 'workspace' in mapping
+        return [
+            mapping for mapping in terra_workspaces if 'workspace' in mapping
             and 'createdBy' in mapping['workspace']
-            and self.isUcscEmail(mapping['workspace']['createdBy'])]
+            and self.isUcscEmail(mapping['workspace']['createdBy'])
+        ]
 
     def isUcscEmail(self, email: str) -> bool:
         return email.endswith('ucsc.edu') or email.endswith('gmail.com')
@@ -728,9 +731,11 @@ class GCPReport(Report):
         self.saveFile(self.generateTerraJsonFileName(date), self.toJson(self.removeNonUcsc(terra_workspaces)))
 
     def addCreatedByToRows(self, rows: Sequence[Mapping], terra_workspaces: Sequence[Mapping]):
-        id_to_created_by = { workspace['googleProject']: workspace['createdBy']
+        id_to_created_by = {
+            workspace['googleProject']: workspace['createdBy']
             for workspace in [mapping['workspace'] for mapping in terra_workspaces if 'workspace' in mapping]
-            if 'googleProject' in workspace and 'createdBy' in workspace }
+            if 'googleProject' in workspace and 'createdBy' in workspace
+        }
         for row in rows:
             id = row['id']
             row['created_by'] = id_to_created_by[id] if id in id_to_created_by else 'Unowned'

--- a/report.py
+++ b/report.py
@@ -706,13 +706,6 @@ class GCPReport(Report):
             return []
         return []
 
-    def removeNonUcsc(self, terra_workspaces: Sequence[Mapping]) -> Sequence[Mapping]:
-        return [
-            mapping for mapping in terra_workspaces if 'workspace' in mapping
-            and 'createdBy' in mapping['workspace']
-            and self.isUcscEmail(mapping['workspace']['createdBy'])
-        ]
-
     def isUcscEmail(self, email: str) -> bool:
         return email.endswith('ucsc.edu') or email.endswith('gmail.com')
 
@@ -726,7 +719,7 @@ class GCPReport(Report):
             ]
         self.save_file(self.generate_billing_csv_file_name(date), self.to_csv(rows))
         terra_workspaces = self.readTerraWorkspaces(self.terra_workspaces_path)
-        self.save_file(self.generate_terra_json_file_name(date), self.to_json(self.removeNonUcsc(terra_workspaces)))
+        self.save_file(self.generate_terra_json_file_name(date), self.to_json(terra_workspaces))
 
     def addCreatedByToRows(self, rows: Sequence[Mapping], terra_workspaces: Sequence[Mapping]):
         id_to_created_by = {

--- a/report.py
+++ b/report.py
@@ -620,7 +620,10 @@ class AWSReport(Report):
         account_name_to_id = {v: k for k, v in self.accounts.items()}
         for day in self.daysOfMonthUpToAndIncluding(date):
             result = self.generateAccountSummary(self.accounts, day, day + datetime.timedelta(1))
-            rows += [{"date": day, "amount_billed": sum(result[name].values()), "account_id": account_name_to_id[name], "account_name": name} for name in result.keys()]
+            rows += [
+                {"date": day, "amount_billed": sum(result[name].values()), "account_id": account_name_to_id[name], "account_name": name}
+                for name in result.keys()
+            ]
         self.saveFile(self.generateBillingCsvFileName(date), self.toCsv(rows))
 
     def generateBetterReport(self) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.28.37
-google-cloud-bigquery==3.4.0
+boto3==1.35.46
+google-cloud-bigquery==3.26.0
 Jinja2==2.11.3
 python-dateutil==2.8.1
 markupsafe==2.0.1

--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -78,7 +78,7 @@
         <a name='{{ id|to_project_id }}' id='{{ id|to_project_id }}'></a>
         <h3>Report for project {{ project }}</h3>
         <p>GCP project ID: <a href="https://console.cloud.google.com/welcome?project={{ id }}">{{ id }}</a>
-        {% if created_by !=  'Unowned' %}
+        {% if created_by != 'Unowned' %}
           <br>Terra workspace created by {{ created_by }}
         {% endif %}
         </p>

--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -73,13 +73,13 @@
     </table>
 
     <h2>Details by project</h2>
-    {% for id, month_total, today_total, project in rows|group_by('id', 'cost_month', 'cost_today', 'name')|sort_by(1) %}
+    {% for id, month_total, today_total, project, created_by in rows|group_by('id', 'cost_month', 'cost_today', 'name', 'created_by')|sort_by(1) %}
       {%- if month_total >= cost_cutoff -%}
         <a name='{{ id|to_project_id }}' id='{{ id|to_project_id }}'></a>
         <h3>Report for project {{ project }}</h3>
         <p>GCP project ID: <a href="https://console.cloud.google.com/welcome?project={{ id }}">{{ id }}</a>
-        {% if id in terra_workspaces and 'createdBy' in terra_workspaces[id] %}
-          <br>Terra workspace created by {{ terra_workspaces[id]['createdBy'] }}
+        {% if created_by !=  'Unowned' %}
+          <br>Terra workspace created by {{ created_by }}
         {% endif %}
         </p>
         <table>


### PR DESCRIPTION
This PR modifies the cloud reporting script to save AWS/GCP cost/usage information to an AWS S3 bucket, so that it can be used for analysis and billing purposes.  The script save the files for the specified platform every time it runs, unless the configuration file has not been properly updated (see below), in which case it operates as before.

AWS and GCP usage information is saved as CSV files, wherein each row represents a day of cost/usage for a particular project/account, and each CSV file represents a month of usage.  The current month's files are updated in place.  Terra account information is logged daily in a JSON file.  The following recursive `ls` output illustrates the structure of files (keys/objects) in the bucket:

```
bash-3.2$ aws s3 ls --recursive <bucket-name>
2024-10-30 14:35:10      35943 aws/2024/10/aws-2024-10.csv
2024-11-13 10:56:35      13876 aws/2024/11/aws-2024-11.csv
2024-10-30 14:27:24     394189 gcp/2024/10/gcp-2024-10.csv
2024-11-13 10:57:56      99626 gcp/2024/11/gcp-2024-11.csv
2024-11-12 09:25:48     180479 terra/2024/11/10/terra-2024-11-10.json
2024-11-13 10:57:57     180479 terra/2024/11/11/terra-2024-11-11.json
```

There is a new block of settings in the `config.json` that specify the target S3 bucket and authorization key information:
```
    "persist": {
        "access_key": "insert AWS access key id here",
        "secret_key": "insert AWS secret key here",
        "bucket": "insert AWS S3 bucket name here"
    }
```

In the spirit of the existing code, identifier/method capitalization style is mixed, but generally consistent locally, and error checking is far from comprehensive.  The code is optimized for stability and consistency between the email report and saved CSVs, at the expense of the number of queries to AWS/GCP infrastructure, which could be optimized...

While developing the PR, we noticed that AWS cost information seems to change slightly over time: if we retrieve the data for a given date X on date X+1d, the costs sometimes vary a few percent from the same data retrieved on date X+Nd, where the range of N is currently not known.  For example, if, on Nov 2, we retrieve the cost data for Nov 1, and then on Nov 10, we again retrieve the cost data for Nov 1, the two data sets will differ slightly.  It's unclear why this is: could be that the data has been reconciled/updated between dates, credits been applied in the interim, or something else.  As long as we're not regarding this AWS data as authoritative, I'm not sure it's worth investigating further...  

Recently, although less than in the past, the AWS report has been observed to not complete - that is, the AWS report email has not been delivered.  We have not determined the cause.  Because these new mods increase the number of AWS queries, if the failure relates to the AWS queries, the script may become more unstable.
