### PR TITLE
Add "Credits by project" table to GCP report

### DIFF
--- a/templates/gcp_report.html
+++ b/templates/gcp_report.html
@@ -147,4 +147,36 @@
       {%- endif -%}
     {% endfor %}
 
+    <h2>Credits by project {{ report_date|ym }}</h2>
+    <table>
+        <thead>
+        <tr>
+            <th>Project Name</th>
+            <th>Unadjusted Cost</th>
+            <th>Billed Amount</th>
+            <th>Credits</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for id, raw_cost_month, cost_month, project, created_by in rows|group_by('id', 'raw_cost_month', 'cost_month', 'name', 'created_by')|sort_by(1) %}
+          {%- if raw_cost_month >= cost_cutoff -%}
+            <tr>
+                <td><a href='#{{ id|to_project_id }}'>{{ project }}</a>{% if created_by != 'Unowned' %} ({{ created_by }}){% endif %}</td>
+                <td>{{ raw_cost_month|print_amount }}</td>
+                <td>{{ cost_month|print_diff }}</td>
+                <td>{{ (raw_cost_month - cost_month)|print_diff }}</td>
+            </tr>
+          {%- endif -%}
+        {% endfor %}
+        </tbody>
+        <tfoot>
+        <tr>
+            <td>Grand total</td>
+            <td>{{ rows|sum_key('raw_cost_month')|print_amount }}</td>
+            <td>{{ rows|sum_key('cost_month')|print_amount }}</td>
+            <td>{{ ((rows|sum_key('raw_cost_month')) - (rows|sum_key('cost_month')))|print_amount }}</td>
+        </tr>
+        </tfoot>
+    </table>
+
 {% endblock main %}


### PR DESCRIPTION
This PR adds a table to the end of the GCP email report that includes the monthly unadjusted cost, billed amount, and credit (difference between unadjusted cost and billed amount) for each project. 